### PR TITLE
Update for compatability with Mojolicious 4.0

### DIFF
--- a/t/with_server.t
+++ b/t/with_server.t
@@ -20,13 +20,13 @@ plugin 'resque', { redis => $redis };
 get '/push' => sub {
     my $self = shift;
     $self->resque( test_queue => { class => 'Test', args => [ 'test' ] } );
-    $self->render_text( 'done' );
+    $self->render( text => 'done' );
 };
 
 get '/pop' => sub {
     my $self = shift;
     my $job = $self->resque->pop('test_queue');
-    $self->render_text( $job->class );
+    $self->render( text => $job->class );
 };
 
 my $t = Test::Mojo->new;


### PR DESCRIPTION
render_text was replaced with render(text => ...) in Mojolicious 4.0.
